### PR TITLE
sort the IP list before piping to uniq

### DIFF
--- a/cachecheck.sh
+++ b/cachecheck.sh
@@ -2,9 +2,9 @@
 #
 #
 #
-#Jamf Pro Extension Attribute to return the active Caching Server
+#Jamf Pro Extension Attribute to return the active Caching Server(s) found by a Mac
 #Note that the return is either a multi-line output of IPs or null if none are found
+#Note - each server is listed once whether it caches iCloud data or just shared assets
 #
-#
-result=`/usr/bin/AssetCacheLocatorUtil 2>&1 | grep guid | awk '{print$4}' | sed 's/^\(.*\):.*$/\1/' | uniq`
+result=`/usr/bin/AssetCacheLocatorUtil 2>&1 | grep guid | awk '{print$4}' | sed 's/^\(.*\):.*$/\1/' | sort | uniq`
 echo "<result>$result</result>"


### PR DESCRIPTION
If you have several caching servers you will end up with results for "personal caching", "personal caching and import", and "shared caching" for each caching server. Sorting the IP before calling uniq gives you a list of the servers as opposed to one entry for each class of asset that's cached.