### PR TITLE
Add check for macOS version 12

### DIFF
--- a/cachecheck.sh
+++ b/cachecheck.sh
@@ -9,7 +9,7 @@
 #
 osvers=$(sw_vers -productVersion | awk -F. '{print $2}')
 
-if [ "$osvers" < "12" ]; then
+if [ "$osvers" -lt "12" ]; then
   result=""
 else
   result=`/usr/bin/AssetCacheLocatorUtil 2>&1 | grep guid | awk '{print$4}' | sed 's/^\(.*\):.*$/\1/' | sort | uniq`

--- a/cachecheck.sh
+++ b/cachecheck.sh
@@ -6,5 +6,12 @@
 #Note that the return is either a multi-line output of IPs or null if none are found
 #
 #
-result=`/usr/bin/AssetCacheLocatorUtil 2>&1 | grep guid | awk '{print$4}' | sed 's/^\(.*\):.*$/\1/' | uniq`
+osvers=$(sw_vers -productVersion | awk -F. '{print $2}')
+
+if [ "$osvers" < "12" ]; then
+  result=""
+else
+  result=`/usr/bin/AssetCacheLocatorUtil 2>&1 | grep guid | awk '{print$4}' | sed 's/^\(.*\):.*$/\1/' | uniq`
+fi
+
 echo "<result>$result</result>"


### PR DESCRIPTION
Since the AssetCacheLocatorUtil binary is part of macOS Sierra, add check to ensure machines running versions less than 12  don't attempt to run the command.