### PR TITLE
add: sort before uniq

### DIFF
--- a/cachecheck.sh
+++ b/cachecheck.sh
@@ -6,5 +6,5 @@
 #Note that the return is either a multi-line output of IPs or null if none are found
 #
 #
-result=`/usr/bin/AssetCacheLocatorUtil 2>&1 | grep guid | awk '{print$4}' | sed 's/^\(.*\):.*$/\1/' | uniq`
+result=`/usr/bin/AssetCacheLocatorUtil 2>&1 | grep guid | awk '{print}' | sed 's/^\(.*\):.*$/\1/'| sort | uniq`
 echo "<result>$result</result>"


### PR DESCRIPTION
uniq requires input which is sorted first, this fixes the bug where multiple lines of the same IP address are returned